### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage of Gxss:
 
 * Checking Single Url
 
-    `echo "https://target.com/some.php?first=hello&last=world | Gxss -c 100 `
+    `echo "https://target.com/some.php?first=hello&last=world" | Gxss -c 100 `
     
 * Checking List of Urls
 


### PR DESCRIPTION
I found that the quarter was missing from README's example, so I send PR it lightly 😉